### PR TITLE
Patch 1 - Fix hash problem with no unescaped links

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 0.6.21
+
+- Fixed unscaped hash in links which are not returned back after processing.
+- Removed extra whitespace appeared after some processed links at the end of sentence in Confluence.
+
 # 0.6.20
 
 - Support for Confluence Cloud option to remove HTML formatting.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # 0.6.21
 
-- Fixed unscaped hash in links which are not returned back after processing.
+- Fixed unescaped hash in links which are not returned back after processing.
 - Removed extra whitespace appeared after some processed links at the end of sentence in Confluence.
 
 # 0.6.20

--- a/foliant/backends/confluence/convert.py
+++ b/foliant/backends/confluence/convert.py
@@ -250,8 +250,9 @@ def confluence_unescape(source: str, escape_dir: str or PosixPath) -> str:
         logger.debug(f'Restoring escaped confluence code with hash {filename}')
         filepath = Path(escape_dir) / filename
         with open(filepath) as f:
-            return f.read()
-    pattern = re.compile(r"\[confluence_escaped hash=\%(?P<hash>.+?)\%\]")
+            return f.read().rstrip(os.linesep)
+    logger.warning(f'confluence_unescape {escape_dir}')
+    pattern = re.compile(r"\[confluence_escaped[ \n\r]+hash=\%(?P<hash>.+?)\%\]")
     return pattern.sub(_sub, source)
 
 

--- a/foliant/backends/confluence/uploader.py
+++ b/foliant/backends/confluence/uploader.py
@@ -192,10 +192,11 @@ class PageUploader:
                 escaped_content = f.read()
                 result = self.post_process_escaped_content(escaped_content, attachment_manager)
                 # attachments.extend(new_attachments)
-                return result
+                return result.rstrip(os.linesep)
         # attachments = []
         escape_dir = self.cachedir / ESCAPE_DIR_NAME
-        pattern = re.compile(r"\[confluence_escaped hash=\%(?P<hash>.+?)\%\]")
+        self.logger.warning(f'PageUploader confluence_unescape {escape_dir}')
+        pattern = re.compile(r"\[confluence_escaped[ \n\r]+hash=\%(?P<hash>.+?)\%\]")
         return pattern.sub(_sub, source)
 
     def post_process_escaped_content(self, escaped_content: str, attachment_manager: AttachmentManager):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='0.6.20',
+    version='0.6.21',
     author='Daniil Minukhin',
     author_email='ddddsa@gmail.com',
     url='https://github.com/foliant-docs/foliantcontrib.confluence',


### PR DESCRIPTION
Fixed problems:
1. Hashes are unescaped in links which are not returned back after processing.
2. Extra whitespace appeared after some processed links at the end of sentence in confluence.

Corrected two files in backend confluence:
- convert.py
- upload.py 