### PR TITLE
Fixed bug with image captions formatting in Confluence

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 0.6.21
+
+- Fixed unscaped hash in links which are not returned back after processing.
+- Removed extra whitespace appeared after some processed links at the end of sentence in Confluence.
+
 # 0.6.20
 
 - Support for Confluence Cloud option to remove HTML formatting.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # 0.6.21
 
-- Fixed unscaped hash in links which are not returned back after processing.
+- Fixed unescaped hash in links which are not returned back after processing.
 - Removed extra whitespace appeared after some processed links at the end of sentence in Confluence.
 
 # 0.6.20

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 0.6.22
+
+- Fix: alt captions of images were stacked up at the end of section.
+- Fix: alt captions didn't appear in browser. 
+- Fix: Imagemagick preprocessor now correctly handles the images without need of additional empty lines or line breaks <br />.
+
 # 0.6.21
 
 - Fixed unescaped hash in links which are not returned back after processing.

--- a/foliant/backends/confluence/convert.py
+++ b/foliant/backends/confluence/convert.py
@@ -43,15 +43,15 @@ def fix_pandoc_images(source: str) -> str:
         Convert image with pandoc <figcaption> tag into classic html image
         with caption in alt=""
         """
-        image_caption = match.group('caption')
+        image_caption = match.group('caption').replace("\n", " ")
         image_path = match.group('path')
         result = f'<img src="{image_path}" alt="{image_caption}">'
         logger.debug(f'\nold: {match.group(0)}\nnew: {result}')
         return result
 
-    image_pattern = re.compile(r'<figure>\s*<img src="(?P<path>.+?)" +(?:alt=".*?")?.+?>(?:<figcaption>(?P<caption>.*?)</figcaption>)\s*</figure>')
-    return image_pattern.sub(_sub_image, source)
-
+    #image_pattern = re.compile(r'<figure>\s*<img src="(?P<path>.+?)" +(?:alt=".*?")?.+?>(?:<figcaption>(?P<caption>.*?)</figcaption>)\s*</figure>')
+    image_pattern = re.compile(r'<figure>\s*<img\s+src="(?P<path>.+?)"\s+(?:alt=".*?")?.+?>\s*(?:<figcaption\s*(?:.*?=".*?")?.*?>(?P<caption>.*?)</figcaption>)\s*</figure>', re.DOTALL)
+    return image_pattern.sub(_sub_image, source)   
 
 def md_to_editor(source: str, temp_dir: PosixPath, pandoc_path: str = 'pandoc'):
     """
@@ -151,9 +151,10 @@ def process_images(source: str,
 
         # attachments.append(new_path)
 
-        attrs = ' '.join(f'{k.replace("_", ":")}="{v}"' for k, v in attrs.items())
-        img_ref = f'<ac:image {attrs}><ri:attachment ri:filename="{new_path.name}"/></ac:image>'
+        attrs = ' '.join(f'{k.replace("_", ":").replace("alt", "ac:title")}="{v}"' for k, v in attrs.items())
+        img_ref = f'<p><ac:image {attrs}><ri:attachment ri:filename="{new_path.name}"/></ac:image></p>'
 
+        logger.debug(f'Attributes of image: {attrs}')
         logger.debug(f'Converted image ref: {img_ref}')
         return img_ref
 

--- a/foliant/backends/confluence/convert.py
+++ b/foliant/backends/confluence/convert.py
@@ -250,8 +250,9 @@ def confluence_unescape(source: str, escape_dir: str or PosixPath) -> str:
         logger.debug(f'Restoring escaped confluence code with hash {filename}')
         filepath = Path(escape_dir) / filename
         with open(filepath) as f:
-            return f.read()
-    pattern = re.compile(r"\[confluence_escaped hash=\%(?P<hash>.+?)\%\]")
+            return f.read().rstrip(os.linesep)
+    logger.warning(f'confluence_unescape {escape_dir}')
+    pattern = re.compile(r"\[confluence_escaped[ \n\r]+hash=\%(?P<hash>.+?)\%\]")
     return pattern.sub(_sub, source)
 
 

--- a/foliant/backends/confluence/uploader.py
+++ b/foliant/backends/confluence/uploader.py
@@ -192,10 +192,11 @@ class PageUploader:
                 escaped_content = f.read()
                 result = self.post_process_escaped_content(escaped_content, attachment_manager)
                 # attachments.extend(new_attachments)
-                return result
+                return result.rstrip(os.linesep)
         # attachments = []
         escape_dir = self.cachedir / ESCAPE_DIR_NAME
-        pattern = re.compile(r"\[confluence_escaped hash=\%(?P<hash>.+?)\%\]")
+        self.logger.warning(f'PageUploader confluence_unescape {escape_dir}')
+        pattern = re.compile(r"\[confluence_escaped[ \n\r]+hash=\%(?P<hash>.+?)\%\]")
         return pattern.sub(_sub, source)
 
     def post_process_escaped_content(self, escaped_content: str, attachment_manager: AttachmentManager):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='0.6.20',
+    version='0.6.21',
     author='Daniil Minukhin',
     author_email='ddddsa@gmail.com',
     url='https://github.com/foliant-docs/foliantcontrib.confluence',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='0.6.21',
+    version='0.6.22',
     author='Daniil Minukhin',
     author_email='ddddsa@gmail.com',
     url='https://github.com/foliant-docs/foliantcontrib.confluence',


### PR DESCRIPTION
Fixed bug with image captions formatting in Confluence

Which problems solved:

1) Fixed ALT image caption in Confluence which now neither disappear nor get stacked away at the end of a section.

2) The spacing before and after the picture is now correct and beautiful. The figure now does not stick to the previous or next paragraph, which required to add extra line breaks `<br />`.

3) Images now work in lists as well. Previously, in order not to break lists, image tags must have been placed without indentation on the next line after a list item. Otherwise the lists were broken. Now the lists may be formatted as usual according to markdown rules.

4) Now user doesn't need to tag the image twice differently - for Confluence and for DOCX/PDF. 
Previously, for Confluence it was necessary to place images within special tags `<ac:image...>`. Meanwhile for other backends (DOCX/PDF) the image formatting was like standard in markdown. 
Now it's enough just to specify a link to the image in usual markdown style or in any of the previously used variants - everything will work correctly.

5) Fixed ImageMagick preprocessor tags (`<magick>..</magick>`) positioning. 
Now they work regardless of position, line spacing, existing line break tags <br /> or any other tags next to or inside <magick>..</magick>. (However, still it's subject to further testing in different conditions)